### PR TITLE
tools for automated VMD rendering

### DIFF
--- a/analyze_foldamers/ensembles/cluster.py
+++ b/analyze_foldamers/ensembles/cluster.py
@@ -40,6 +40,10 @@ def get_representative_structures(
     if not os.path.exists(output_dir):
         os.mkdir(output_dir)    
     
+    if type(file_list) == str:
+        # If a single file, make into list:
+        file_list = file_list.split()
+    
     file_list_out = []
     
     for file in file_list:

--- a/analyze_foldamers/ensembles/cluster.py
+++ b/analyze_foldamers/ensembles/cluster.py
@@ -13,6 +13,56 @@ from cg_openmm.utilities.iotools import write_pdbfile_without_topology
 from sklearn_extra.cluster import KMedoids
 from scipy.optimize import minimize    
     
+def get_representative_structures(
+    file_list, cgmodel,
+    frame_start=0, frame_stride=1, frame_end=-1,
+    output_format="pdb", output_dir="cluster_output"):
+    """
+    Using the similarity matrix from RMSD distances, determine a representative structure for each
+    file in file_list    
+
+    :param file_list: A list of PDB or DCD files to read and concatenate
+    :type file_list: List( str )
+    
+    :param cgmodel: A CGModel() class object
+    :type cgmodel: class
+    
+    :param frame_start: First frame in pdb trajectory file to use for clustering.
+    :type frame_start: int
+
+    :param frame_stride: Advance by this many frames when reading trajectories.
+    :type frame_stride: int
+
+    :param frame_end: Last frame in trajectory file to use for clustering.
+    :type frame_end: int
+    """
+    
+    if not os.path.exists(output_dir):
+        os.mkdir(output_dir)    
+    
+    file_list_out = []
+    
+    for file in file_list:
+        distances, traj_all = get_rmsd_matrix(file, cgmodel, frame_start, frame_stride, frame_end)
+        # Compute medoid based on similarity scores:
+        medoid_index = np.exp(-distances/distances.std()).sum(axis=1).argmax()
+            
+        medoid_xyz = traj_all[medoid_index].xyz[0]
+
+        positions = medoid_xyz * unit.nanometer
+        file_name = str(f"{file[:-4]}_sim.{output_format}")
+        file_list_out.append(file_name)
+        if output_format=="dcd":
+            dcdtraj = md.Trajectory(
+                xyz=positions.value_in_unit(unit.nanometer),
+                topology=md.Topology.from_openmm(cgmodel.topology),
+            )
+            md.Trajectory.save_dcd(dcdtraj,file_name)
+        else:
+            cgmodel.positions = positions
+            write_pdbfile_without_topology(cgmodel, file_name)
+        
+    return file_list_out
     
 def get_cluster_medoid_positions_KMedoids(
     file_list, cgmodel, n_clusters=2,
@@ -624,6 +674,11 @@ def get_rmsd_matrix(file_list, cgmodel, frame_start, frame_stride, frame_end):
     
     # Load files as {replica number: replica trajectory}
     rep_traj = {}
+    
+    if type(file_list) == str:
+        # If a single file, make into list:
+        file_list = file_list.split()    
+ 
     for i in range(len(file_list)):
         if file_list[0][-3:] == 'dcd':
             rep_traj[i] = md.load(file_list[i],top=md.Topology.from_openmm(cgmodel.topology))

--- a/analyze_foldamers/utilities/snapshot.py
+++ b/analyze_foldamers/utilities/snapshot.py
@@ -19,6 +19,6 @@ def take_snapshot(file_list):
         file_str = file_str[:-1]
     
     try:
-        os.system(f'vmd -dispdev text -f {file_str} -e render_snapshot.vmd')
+        os.system(f'vmd -dispdev text -e render_snapshot.vmd -args {file_str}')
     except:
         print('VMD is required to use this function')

--- a/analyze_foldamers/utilities/snapshot.py
+++ b/analyze_foldamers/utilities/snapshot.py
@@ -1,0 +1,24 @@
+import os
+import numpy as np
+
+def take_snapshot(file_list):
+    """
+    For each file in file_list (pdb), render molecular snapshot in VMD. All files are loaded
+    into VMD at once, and each frame is rendered as a bitmap file.
+    
+    """
+    
+    if type(file_list) == str:
+        # Single file
+        file_str = file_list
+    elif type(file_list) == list:
+        # Create space separated strings to load as one molecule with multiple frames
+        file_str = file_list[0].ljust(len(file_list[0])+1)
+        for i in range(1,len(file_list)):
+            file_str += file_list[i].ljust(len(file_list[i])+1)
+        file_str = file_str[:-1]
+    
+    try:
+        os.system(f'vmd -dispdev text -f {file_str} -e render_snapshot.vmd')
+    except:
+        print('VMD is required to use this function')

--- a/examples/visualization/render_snapshot.vmd
+++ b/examples/visualization/render_snapshot.vmd
@@ -6,6 +6,20 @@ axes location off
 # Set background color
 color Display Background white
 
+# Load in molecules:
+# argv is a list of files
+
+set n_files [llength $argv]
+
+set file0 [lindex $argv 0]
+
+mol new $file0 autobonds off
+
+for {set i 1} {$i < $n_files} {incr i} {
+  set file_i [lindex $argv $i]
+  mol addfile $file_i autobonds off
+  }
+
 # Set representation and material
 mol modmaterial 0 0 Glossy
 mol representation Licorice

--- a/examples/visualization/render_snapshot.vmd
+++ b/examples/visualization/render_snapshot.vmd
@@ -1,0 +1,26 @@
+# This script renders each frame loaded into VMD
+
+# Turn axes off
+axes location off
+
+# Set background color
+color Display Background white
+
+# Set representation and material
+mol modmaterial 0 0 Glossy
+mol representation Licorice
+mol modstyle 0 0 Licorice 0.2 12.0 12.0
+
+# Select frame(s)
+set n_frames [molinfo top get numframes]
+
+for {set frame_i 0} {$frame_i < $n_frames} {incr frame_i} {
+  animate goto $frame_i
+  display resize 1024 1024
+  display resetview
+
+  # Render with TachyonInternal
+  render TachyonInternal snapshot_$frame_i.bmp
+  }
+  
+exit

--- a/examples/visualization/take_state_snapshots.py
+++ b/examples/visualization/take_state_snapshots.py
@@ -1,0 +1,34 @@
+import os
+import numpy as np
+import matplotlib.pyplot as pyplot
+import mdtraj as md
+from simtk import unit
+from cg_openmm.cg_model.cgmodel import CGModel
+from analyze_foldamers.ensembles.cluster import *
+from analyze_foldamers.utilities.snapshot import *
+import pickle
+
+# This example determines representative structures of a series of state trajectories,
+# and renders each structure using VMD.
+# ***Note: VMD must first be installed before using the function
+
+# Load in a trajectory pdb file:
+traj_file_list = []
+nreplica=12
+
+for i in range(nreplica):
+    traj_file_list.append(f"output/state_{i+1}.dcd")
+    
+# Load in a CGModel:
+cgmodel = pickle.load(open("stored_cgmodel.pkl","rb"))
+    
+# Determine representative structures:
+file_list_out = get_representative_structures(
+    traj_file_list, cgmodel, output_dir="output",
+    frame_start=1000, frame_stride=100)
+
+# Create snapshots using VMD TachyonInternal renderer
+take_snapshot(file_list_out)
+
+
+


### PR DESCRIPTION
## Description
Adding functionality for rendering snapshots of a list of files, using VMD TachyonInternal renderer. The example in examples/visualization finds representative structures for a list of state trajectories using similarity scores computed from the RMSD distance matrix, and creates bitmap images for each structure.

Since VMD is operated in text (no display window) mode, we don't need to use X11 forwarding for remote computers to do the rendering.

Still a number of issues to sort out with this, but the example ran ok for me.

Ignoring the autobonds issue, we get something like this:

![image](https://user-images.githubusercontent.com/64790444/100011833-504a5c80-2da0-11eb-8621-a4f43d36515c.png)

## Todos
  - [ ] Make sure VMD closes in case of an error
  - [x] Implement 'autobonds off' when loading PDB files - this is pretty important
  - [ ] Pass VMD options (such as output directory, materials, colors, resolution) from the python script to the VMD Tcl script
  - [ ] Figure out how to optimize the view angle. For example, sometimes the default view is looking down into a helix from the top.

## Status
- [ ] Ready to go