### PR TITLE
General 2d hist

### DIFF
--- a/analyze_foldamers/parameters/angle_distributions.py
+++ b/analyze_foldamers/parameters/angle_distributions.py
@@ -58,8 +58,8 @@ def assign_angle_types(cgmodel, angle_list):
             ang_dict[reverse_string_name] = i_angle_type
             # For inverse dict we will use only the forward name based on first encounter
             inv_ang_dict[str(i_angle_type)] = string_name
-            print(f"adding new angle type {i_angle_type}: {string_name} to dictionary")
-            print(f"adding reverse version {i_angle_type}: {reverse_string_name} to dictionary")
+            # print(f"adding new angle type {i_angle_type}: {string_name} to dictionary")
+            # print(f"adding reverse version {i_angle_type}: {reverse_string_name} to dictionary")
             
         ang_types.append(ang_dict[string_name])
                     
@@ -123,8 +123,8 @@ def assign_torsion_types(cgmodel, torsion_list):
             # For inverse dict we will use only the forward name based on first encounter
             inv_torsion_dict[str(i_torsion_type)] = string_name
             
-            print(f"adding new torsion type {i_torsion_type}: {string_name} to dictionary")
-            print(f"adding reverse version {i_torsion_type}: {reverse_string_name} to dictionary")
+            # print(f"adding new torsion type {i_torsion_type}: {string_name} to dictionary")
+            # print(f"adding reverse version {i_torsion_type}: {reverse_string_name} to dictionary")
             
             
         torsion_types.append(torsion_dict[string_name])
@@ -472,12 +472,6 @@ def calc_2d_distribution(
         yvar_name_reverse += "_"
     yvar_name_reverse = yvar_name_reverse[:-1]
     
-    print(xvar_name)
-    print(xvar_name_reverse)
-    
-    print(yvar_name)
-    print(yvar_name_reverse)
-    
     for file in file_list:
     
         # Load in a trajectory file:
@@ -704,8 +698,6 @@ def calc_2d_distribution(
         xvar_val_array_combo[file] = np.reshape(xvar_val_array_combo[file], (nframes*n_occ_x*n_occ_y,1))
         yvar_val_array_combo[file] = np.reshape(yvar_val_array_combo[file], (nframes*n_occ_x*n_occ_y,1))        
         
-        print(xvar_val_array_combo[file].shape)
-        
     # 2d histogram the data and plot:
     hist_data, xedges, yedges = plot_2d_distribution(
         file_list, xvar_val_array_combo, yvar_val_array_combo, xvar_bin_edges, yvar_bin_edges,
@@ -898,8 +890,6 @@ def plot_2d_distribution(file_list, xvar_val_array, yvar_val_array, xvar_bin_edg
         # Accounting for blank gridspec at the borders:
         row = int(np.ceil(subplot_id/(ncol-2)))
         col = 1+int((subplot_id-1)%(ncol-2))
-        
-        print(f'{row} {col}')
         
         # axs subplot object is only subscriptable in dimensions it has multiple entries in
         if nrow > 1 and ncol > 1: 

--- a/analyze_foldamers/parameters/angle_distributions.py
+++ b/analyze_foldamers/parameters/angle_distributions.py
@@ -4,6 +4,7 @@ import mdtraj as md
 from simtk import unit
 from cg_openmm.cg_model.cgmodel import CGModel
 from analyze_foldamers.utilities.plot import plot_distribution
+from analyze_foldamers.parameters.bond_distributions import *
 import matplotlib
 import matplotlib.pyplot as plt
 import matplotlib.gridspec as gridspec
@@ -369,6 +370,343 @@ def calc_torsion_distribution(
     return torsion_hist_data
     
 
+def calc_2d_distribution(
+    cgmodel,
+    file_list,
+    nbin_xvar=180,
+    nbin_yvar=180,
+    frame_start=0,
+    frame_stride=1,
+    frame_end=-1,
+    plotfile="2d_hist.pdf",
+    xvar_name = "bb_bb_bb",
+    yvar_name = "bb_bb_bb_bb",
+    colormap="Spectral",
+):      
+
+    """
+    Calculate and plot 2d histogramt for any 2 bonded variables,
+    given a CGModel object and pdb or dcd trajectory.
+
+    :param cgmodel: CGModel() object
+    :type cgmodel: class
+    
+    :param file_list: path to pdb or dcd trajectory file(s) - can be a list or single string
+    :type file_list: str or list(str)
+    
+    :param nbin_xvar: number of bins for x bonded variable (spanning from 0 to 180 degrees)
+    :type nbin_xvar: int
+    
+    :param nbin_yvar: number of bins for y bonded variable (spanning from -180 to +180 degrees)
+    :type nbin_yvar:
+    
+    :param frame_start: First frame in trajectory file to use for analysis.
+    :type frame_start: int
+
+    :param frame_stride: Advance by this many frames when reading trajectories.
+    :type frame_stride: int
+
+    :param frame_end: Last frame in trajectory file to use for analysis.
+    :type frame_end: int
+    
+    :param plotfile: Filename for saving torsion distribution pdf plots
+    :type plotfile: str
+    
+    :param xvar_name: particle sequence of the x bonded parameter (default="bb_bb_bb") - for now only single sequence permitted
+    :type xvar_name: str
+    
+    :param yvar_name: particle sequence of the y bonded parameter (default="bb_bb_bb_bb") - for now only single sequence permitted
+    :type yvar_name: str    
+    
+    :param colormap: matplotlib pyplot colormap to use (default='Spectral')
+    :type colormap: str (case sensitive)
+    
+    """
+    
+    # Convert file_list to list if a single string:
+    if type(file_list) == str:
+        # Single file
+        file_list = file_list.split()
+    
+    # Store angle, torsion values by filename for computing global colormap
+    xvar_val_array = {}
+    yvar_val_array = {}
+    
+    # Store the reverse name of the bonded type (need to check both)
+    
+    # x variable
+    particle_list = []
+    particle = ""
+    for c in xvar_name:
+        if c == '_':
+            particle_list.append(particle)
+            particle = ""
+        else:
+            particle += c
+    particle_list.append(particle)
+    
+    particle_list_reverse = particle_list[::-1]
+    xvar_name_reverse = ""
+    for par in particle_list:
+        xvar_name_reverse += par
+        xvar_name_reverse += "_"
+    xvar_name_reverse = xvar_name_reverse[:-1]
+    
+    # y variable
+    particle_list = []
+    particle = ""
+    for c in yvar_name:
+        if c == '_':
+            particle_list.append(particle)
+            particle = ""
+        else:
+            particle += c
+    particle_list.append(particle)
+    
+    particle_list_reverse = particle_list[::-1]
+    yvar_name_reverse = ""
+    for par in particle_list:
+        yvar_name_reverse += par
+        yvar_name_reverse += "_"
+    yvar_name_reverse = yvar_name_reverse[:-1]
+    
+    
+    for file in file_list:
+    
+        # Load in a trajectory file:
+        if file[-3:] == 'dcd':
+            traj = md.load(file,top=md.Topology.from_openmm(cgmodel.topology))
+        else:
+            traj = md.load(file)
+            
+            
+        # Select frames for analysis:    
+        if frame_end == -1:
+            frame_end = traj.n_frames
+
+        traj = traj[frame_start:frame_end:frame_stride]             
+            
+        nframes = traj.n_frames
+        
+        # x variable   
+        
+        # Determine parameter type of xvar:
+        n_particle_x = xvar_name.count('_')+1
+        
+        if n_particle_x == 2:
+            # Bond
+           
+            # Get bond list
+            bond_list = CGModel.get_bond_list(cgmodel)
+            
+            # Assign bond types:
+            bond_types, bond_array, bond_sub_arrays, n_i, i_bond_type, bond_dict, inv_bond_dict = \
+                assign_bond_types(cgmodel, bond_list)
+            
+            for i in range(i_bond_type):
+                if inv_bond_dict[str(i+1)] == xvar_name or inv_bond_dict[str(i+1)] == xvar_name_reverse:
+                    # Compute all bond length values in trajectory
+                    # This returns an [nframes x n_bonds] array
+                    xvar_val_array[file] = md.compute_distances(traj,bond_sub_arrays[str(i+1)])
+                    
+                    # We will have different numbers of bonds and torsion angle.
+                    # We will set a convention of omitting the first and last bonds
+                    
+                    # Reshape array:
+                    xvar_val_array[file] = np.reshape(xvar_val_array[file][:,1:-1], (nframes*(n_i[i]-2)[0],1))
+                    
+                    # Get equilibrium value:
+                    b_eq = cgmodel.get_bond_length(bond_sub_arrays[str(i+1)][0])
+                    
+            # Set bin edges:
+            # This should be the same across all files - use heuristic from equilibrium bond length
+            b_min = 0.5*b_eq.value_in_unit(unit.nanometer)
+            b_max = 1.5*b_eq.value_in_unit(unit.nanometer)
+           
+            xvar_bin_edges = np.linspace(b_min,b_max,nbin_xvar+1)
+            xvar_bin_centers = np.zeros((len(xvar_bin_edges)-1,1))
+            for i in range(len(xvar_bin_edges)-1):
+                xvar_bin_centers[i] = (xvar_bin_edges[i]+xvar_bin_edges[i+1])/2  
+                
+            xlabel = f'{xvar_name} distance ({unit.nanometer})'
+                    
+        elif n_particle_x == 3:
+            # Angle
+            
+            # Get angle list
+            angle_list = CGModel.get_bond_angle_list(cgmodel)
+        
+            # Assign angle types:
+            ang_types, ang_array, ang_sub_arrays, n_i, i_angle_type, ang_dict, inv_ang_dict = \
+                assign_angle_types(cgmodel, angle_list)
+                
+            # Set bin edges:
+            xvar_bin_edges = np.linspace(0,180,nbin_xvar+1)
+            xvar_bin_centers = np.zeros((len(xvar_bin_edges)-1,1))
+            for i in range(len(xvar_bin_edges)-1):
+                xvar_bin_centers[i] = (xvar_bin_edges[i]+xvar_bin_edges[i+1])/2    
+            
+            for i in range(i_angle_type):
+                if inv_ang_dict[str(i+1)] == xvar_name or inv_ang_dict[str(i+1)] == xvar_name_reverse:
+                    # Compute all angle values in trajectory
+                    # This returns an [nframes x n_angles] array
+                    xvar_val_array[file] = md.compute_angles(traj,ang_sub_arrays[str(i+1)])
+                    
+                    # We will have different numbers of bond-bending angle and torsion angle.
+                    # We will set a convention of omitting the last angle value.
+                    
+                    # Convert to degrees and exclude last angle:  
+                    xvar_val_array[file] = (180/np.pi)*xvar_val_array[file][:,:-1]
+                    
+                    # Reshape array:
+                    xvar_val_array[file] = np.reshape(xvar_val_array[file], (nframes*(n_i[i]-1)[0],1))
+                    
+            xlabel = f'{xvar_name} angle (degrees)'
+                
+        elif n_particle_x == 4:
+            # Torsion
+            
+            # Get torsion list
+            torsion_list = CGModel.get_torsion_list(cgmodel)
+
+            # Assign torsion types
+            torsion_types, torsion_array, torsion_sub_arrays, n_j, i_torsion_type, torsion_dict, inv_torsion_dict = \
+                assign_torsion_types(cgmodel, torsion_list)
+            
+            # Set bin edges:
+            xvar_bin_edges = np.linspace(-180,180,nbin_xvar+1)
+            xvar_bin_centers = np.zeros((len(xvar_bin_edges)-1,1))
+            for i in range(len(xvar_bin_edges)-1):
+                xvar_bin_centers[i] = (xvar_bin_edges[i]+xvar_bin_edges[i+1])/2
+                
+            for i in range(i_torsion_type):
+                if inv_torsion_dict[str(i+1)] == xvar_name or inv_torsion_dict[str(i+1)] == xvar_name_reverse:
+                    # Compute all torsion values in trajectory
+                    # This returns an [nframes x n_torsions] array
+                    xvar_val_array[file] = md.compute_dihedrals(
+                        traj,torsion_sub_arrays[str(i+1)])
+                    
+                    # Convert to degrees:  
+                    xvar_val_array[file] *= (180/np.pi)
+                    
+                    # Reshape array
+                    xvar_val_array[file] = np.reshape(xvar_val_array[file], (nframes*n_j[i][0],1))
+                    
+            xlabel = f'{xvar_name} angle (degrees)'
+                    
+        # y variable   
+        
+        # Determine parameter type of yvar:
+        n_particle_y = yvar_name.count('_')+1
+        
+        if n_particle_y == 2:
+            # Bond
+           
+            # Get bond list
+            bond_list = CGModel.get_bond_list(cgmodel)
+            
+            # Assign bond types:
+            bond_types, bond_array, bond_sub_arrays, n_i, i_bond_type, bond_dict, inv_bond_dict = \
+                assign_bond_types(cgmodel, bond_list)
+            
+            for i in range(i_bond_type):
+                if inv_bond_dict[str(i+1)] == yvar_name or inv_bond_dict[str(i+1)] == yvar_name_reverse:
+                    # Compute all bond length values in trajectory
+                    # This returns an [nframes x n_bonds] array
+                    yvar_val_array[file] = md.compute_distances(traj,bond_sub_arrays[str(i+1)])
+                    
+                    # We will have different numbers of bonds and torsion angle.
+                    # We will set a convention of omitting the first and last bonds
+                    
+                    # Reshape array:
+                    yvar_val_array[file] = np.reshape(yvar_val_array[file][:,1:-1], (nframes*(n_i[i]-2)[0],1))
+                    
+                    # Get equilibrium value:
+                    b_eq = cgmodel.get_bond_length(bond_sub_arrays[str(i+1)][0])
+                    
+            # Set bin edges:
+            # This should be the same across all files - use heuristic from equilibrium bond length
+            b_min = 0.5*b_eq.value_in_unit(unit.nanometer)
+            b_max = 1.5*b_eq.value_in_unit(unit.nanometer)
+           
+            yvar_bin_edges = np.linspace(b_min,b_max,nbin_yvar+1)
+            yvar_bin_centers = np.zeros((len(yvar_bin_edges)-1,1))
+            for i in range(len(yvar_bin_edges)-1):
+                yvar_bin_centers[i] = (yvar_bin_edges[i]+yvar_bin_edges[i+1])/2  
+                
+            ylabel = f'{yvar_name} distance ({unit.nanometer})'
+                    
+        elif n_particle_y == 3:
+            # Angle
+            
+            # Get angle list
+            angle_list = CGModel.get_bond_angle_list(cgmodel)
+        
+            # Assign angle types:
+            ang_types, ang_array, ang_sub_arrays, n_i, i_angle_type, ang_dict, inv_ang_dict = \
+                assign_angle_types(cgmodel, angle_list)
+                
+            # Set bin edges:
+            yvar_bin_edges = np.linspace(0,180,nbin_yvar+1)
+            yvar_bin_centers = np.zeros((len(yvar_bin_edges)-1,1))
+            for i in range(len(yvar_bin_edges)-1):
+                yvar_bin_centers[i] = (yvar_bin_edges[i]+yvar_bin_edges[i+1])/2    
+            
+            for i in range(i_angle_type):
+                if inv_ang_dict[str(i+1)] == yvar_name or inv_ang_dict[str(i+1)] == yvar_name_reverse:
+                    # Compute all angle values in trajectory
+                    # This returns an [nframes x n_angles] array
+                    yvar_val_array[file] = md.compute_angles(traj,ang_sub_arrays[str(i+1)])
+                    
+                    # We will have different numbers of bond-bending angle and torsion angle.
+                    # We will set a convention of omitting the last angle value.
+                    
+                    # Convert to degrees and exclude last angle:  
+                    yvar_val_array[file] = (180/np.pi)*yvar_val_array[file][:,:-1]
+                    
+                    # Reshape array:
+                    yvar_val_array[file] = np.reshape(yvar_val_array[file], (nframes*(n_i[i]-1)[0],1))
+                    
+            ylabel = f'{yvar_name} angle (degrees)'
+                
+        elif n_particle_y == 4:
+            # Torsion
+            
+            # Get torsion list
+            torsion_list = CGModel.get_torsion_list(cgmodel)
+
+            # Assign torsion types
+            torsion_types, torsion_array, torsion_sub_arrays, n_j, i_torsion_type, torsion_dict, inv_torsion_dict = \
+                assign_torsion_types(cgmodel, torsion_list)
+            
+            # Set bin edges:
+            yvar_bin_edges = np.linspace(-180,180,nbin_yvar+1)
+            yvar_bin_centers = np.zeros((len(yvar_bin_edges)-1,1))
+            for i in range(len(yvar_bin_edges)-1):
+                yvar_bin_centers[i] = (yvar_bin_edges[i]+yvar_bin_edges[i+1])/2
+                
+            for i in range(i_torsion_type):
+                if inv_torsion_dict[str(i+1)] == yvar_name or inv_torsion_dict[str(i+1)] == yvar_name_reverse:
+                    # Compute all torsion values in trajectory
+                    # This returns an [nframes x n_torsions] array
+                    yvar_val_array[file] = md.compute_dihedrals(
+                        traj,torsion_sub_arrays[str(i+1)])
+                    
+                    # Convert to degrees:  
+                    yvar_val_array[file] *= (180/np.pi)
+                    
+                    # Reshape array
+                    yvar_val_array[file] = np.reshape(yvar_val_array[file], (nframes*n_j[i][0],1))
+
+            ylabel = f'{yvar_name} angle (degrees)'
+            
+    # 2d histogram the data and plot:
+    hist_data, xedges, yedges = plot_2d_distribution(
+        file_list, xvar_val_array, yvar_val_array, xvar_bin_edges, yvar_bin_edges,
+        plotfile, colormap, xlabel, ylabel)
+    
+    return hist_data, xedges, yedges
+    
 def calc_ramachandran(
     cgmodel,
     file_list,
@@ -502,15 +840,15 @@ def calc_ramachandran(
                 torsion_val_array[file] = np.reshape(torsion_val_array[file], (nframes*n_j[i][0],1))
         
     # 2d histogram the data and plot:
-    hist_data, xedges, yedges = plot_ramachandran(
-        file_list, ang_val_array, torsion_val_array, angle_bin_edges, torsion_bin_edges,
-        plotfile, colormap)
+    hist_data, xedges, yedges = plot_2d_distribution(
+        file_list, torsion_val_array, ang_val_array, torsion_bin_edges, angle_bin_edges,
+        plotfile, colormap, xlabel='Alpha (degrees)', ylabel='Theta (degrees)')
     
     return hist_data, xedges, yedges
     
     
-def plot_ramachandran(file_list, ang_val_array, torsion_val_array, angle_bin_edges, torsion_bin_edges,
-    plotfile, colormap): 
+def plot_2d_distribution(file_list, xvar_val_array, yvar_val_array, xvar_bin_edges, yvar_bin_edges,
+    plotfile, colormap, xlabel, ylabel): 
     """Internal function for 2d histogramming angle data and creating ramachandran plots"""
     
     # Store 2d histogram output
@@ -555,27 +893,27 @@ def plot_ramachandran(file_list, ang_val_array, torsion_val_array, angle_bin_edg
         if nrow > 1 and ncol > 1: 
             ax = figure.add_subplot(fig_specs[row,col])
             hist_data_out, xedges_out, yedges_out, image_out = ax.hist2d(
-                torsion_val_array[file][:,0],
-                ang_val_array[file][:,0],
-                bins=[torsion_bin_edges,angle_bin_edges],
+                xvar_val_array[file][:,0],
+                yvar_val_array[file][:,0],
+                bins=[xvar_bin_edges,yvar_bin_edges],
                 density=True,
             )
         
         if ncol > 1 and nrow == 1:
             ax = figure.add_subplot(fig_specs[row,col])
             hist_data_out, xedges_out, yedges_out, image_out = ax.hist2d(
-                torsion_val_array[file][:,0],
-                ang_val_array[file][:,0],
-                bins=[torsion_bin_edges,angle_bin_edges],
+                xvar_val_array[file][:,0],
+                yvar_val_array[file][:,0],
+                bins=[xvar_bin_edges,yvar_bin_edges],
                 density=True,
             )
             
         if ncol == 1 and nrow == 1:
             ax = figure.add_subplot(fig_specs[row,col])
             hist_data_out, xedges_out, yedges_out, image_out = ax.hist2d(
-                torsion_val_array[file][:,0],
-                ang_val_array[file][:,0],
-                bins=[torsion_bin_edges,angle_bin_edges],
+                xvar_val_array[file][:,0],
+                yvar_val_array[file][:,0],
+                bins=[xvar_bin_edges,yvar_bin_edges],
                 density=True,
             )        
         
@@ -625,9 +963,9 @@ def plot_ramachandran(file_list, ang_val_array, torsion_val_array, angle_bin_edg
         if nrow > 1 and ncol > 1: 
             ax = figure.add_subplot(fig_specs[row,col])
             hist_data_out, xedges_out, yedges_out, image_out = ax.hist2d(
-                torsion_val_array[file][:,0],
-                ang_val_array[file][:,0],
-                bins=[torsion_bin_edges,angle_bin_edges],
+                xvar_val_array[file][:,0],
+                yvar_val_array[file][:,0],
+                bins=[xvar_bin_edges,yvar_bin_edges],
                 density=True,
                 cmap=cmap,
                 norm=norm,
@@ -636,9 +974,9 @@ def plot_ramachandran(file_list, ang_val_array, torsion_val_array, angle_bin_edg
         if ncol > 1 and nrow == 1:
             ax = figure.add_subplot(fig_specs[row,col])
             hist_data_out, xedges_out, yedges_out, image_out = ax.hist2d(
-                torsion_val_array[file][:,0],
-                ang_val_array[file][:,0],
-                bins=[torsion_bin_edges,angle_bin_edges],
+                xvar_val_array[file][:,0],
+                yvar_val_array[file][:,0],
+                bins=[xvar_bin_edges,yvar_bin_edges],
                 density=True,
                 cmap=cmap,
                 norm=norm,
@@ -647,9 +985,9 @@ def plot_ramachandran(file_list, ang_val_array, torsion_val_array, angle_bin_edg
         if ncol == 1 and nrow == 1:
             ax = figure.add_subplot(fig_specs[row,col])
             hist_data_out, xedges_out, yedges_out, image_out = ax.hist2d(
-                torsion_val_array[file][:,0],
-                ang_val_array[file][:,0],
-                bins=[torsion_bin_edges,angle_bin_edges],
+                xvar_val_array[file][:,0],
+                yvar_val_array[file][:,0],
+                bins=[xvar_bin_edges,yvar_bin_edges],
                 density=True,
                 cmap=cmap,
                 norm=norm,
@@ -677,10 +1015,10 @@ def plot_ramachandran(file_list, ang_val_array, torsion_val_array, angle_bin_edg
         pad=0,
         label='probability density')       
     
-    ax_south.set_xlabel("Alpha (degrees)", fontsize=14)
+    ax_south.set_xlabel(xlabel, fontsize=14)
     ax_south.xaxis.set_label_coords(0.5,0.5)
     
-    ax_west.set_ylabel("Theta (degrees)", fontsize=14)
+    ax_west.set_ylabel(ylabel, fontsize=14)
     ax_west.yaxis.set_label_coords(0.5,0.5)
     
     ax_east.tick_params(labelcolor='none', top=False, bottom=False, left=False, right=False)

--- a/analyze_foldamers/parameters/angle_distributions.py
+++ b/analyze_foldamers/parameters/angle_distributions.py
@@ -178,6 +178,9 @@ def calc_bond_angle_distribution(
     :param plotfile: Base filename for saving bond angle distribution pdf plots
     :type plotfile: str
     
+    :returns:
+       - torsion_hist_data ( dict )    
+    
     """
     
     # Convert file_list to list if a single string:
@@ -291,6 +294,10 @@ def calc_torsion_distribution(
     
     :param plotfile: Base filename for saving torsion distribution pdf plots
     :type plotfile: str
+    
+    :returns:
+       - torsion_hist_data ( dict )
+    
     """
     
     # Convert file_list to list if a single string:
@@ -385,7 +392,7 @@ def calc_2d_distribution(
     ):      
 
     """
-    Calculate and plot 2d histogramt for any 2 bonded variables,
+    Calculate and plot 2d histogram for any 2 bonded variables,
     given a CGModel object and pdb or dcd trajectory.
 
     :param cgmodel: CGModel() object
@@ -394,10 +401,10 @@ def calc_2d_distribution(
     :param file_list: path to pdb or dcd trajectory file(s) - can be a list or single string
     :type file_list: str or list(str)
     
-    :param nbin_xvar: number of bins for x bonded variable (spanning from 0 to 180 degrees)
+    :param nbin_xvar: number of bins for x bonded variable
     :type nbin_xvar: int
     
-    :param nbin_yvar: number of bins for y bonded variable (spanning from -180 to +180 degrees)
+    :param nbin_yvar: number of bins for y bonded variable
     :type nbin_yvar:
     
     :param frame_start: First frame in trajectory file to use for analysis.
@@ -412,15 +419,19 @@ def calc_2d_distribution(
     :param plotfile: Filename for saving torsion distribution pdf plots
     :type plotfile: str
     
-    :param xvar_name: particle sequence of the x bonded parameter (default="bb_bb_bb") - for now only single sequence permitted
+    :param xvar_name: particle sequence of the x bonded parameter (default="bb_bb_bb")
     :type xvar_name: str
     
-    :param yvar_name: particle sequence of the y bonded parameter (default="bb_bb_bb_bb") - for now only single sequence permitted
+    :param yvar_name: particle sequence of the y bonded parameter (default="bb_bb_bb_bb")
     :type yvar_name: str    
     
     :param colormap: matplotlib pyplot colormap to use (default='Spectral')
     :type colormap: str (case sensitive)
     
+    :returns:
+       - hist_data ( dict )
+       - xedges ( dict )
+       - yedges ( dict )
     """
     
     # Convert file_list to list if a single string:
@@ -479,7 +490,6 @@ def calc_2d_distribution(
             traj = md.load(file,top=md.Topology.from_openmm(cgmodel.topology))
         else:
             traj = md.load(file)
-            
             
         # Select frames for analysis:    
         if frame_end == -1:
@@ -677,7 +687,7 @@ def calc_2d_distribution(
     xvar_val_array_combo = {}
     yvar_val_array_combo = {}
     
-    # Each array of single observables in [n_frames x n_occurances]
+    # Each array of single observables is [n_frames x n_occurances]
     # x value arrays should be [xval0_y0, xval1_y0, ...xvaln_y0, ... xval0_yn, xval1_yn, xvaln_yn]
     # y value arrays should be [yval0_x0, yval0_x1, ...yval0_xn, ... yvaln_x0, yvaln_x1, yvaln_xn]
     
@@ -756,6 +766,10 @@ def calc_ramachandran(
     :param colormap: matplotlib pyplot colormap to use (default='Spectral')
     :type colormap: str (case sensitive)
     
+    :returns:
+       - hist_data ( dict )
+       - xedges ( dict )
+       - yedges ( dict )
     """
     
     # Convert file_list to list if a single string:
@@ -848,7 +862,7 @@ def calc_ramachandran(
     
 def plot_2d_distribution(file_list, xvar_val_array, yvar_val_array, xvar_bin_edges, yvar_bin_edges,
     plotfile, colormap, xlabel, ylabel): 
-    """Internal function for 2d histogramming angle data and creating ramachandran plots"""
+    """Internal function for 2d histogramming bonded observable data and creating 2d plots"""
     
     # Store 2d histogram output
     hist_data = {}

--- a/analyze_foldamers/parameters/angle_distributions.py
+++ b/analyze_foldamers/parameters/angle_distributions.py
@@ -179,7 +179,7 @@ def calc_bond_angle_distribution(
     :type plotfile: str
     
     :returns:
-       - torsion_hist_data ( dict )    
+       - angle_hist_data ( dict )    
     
     """
     

--- a/analyze_foldamers/parameters/bond_distributions.py
+++ b/analyze_foldamers/parameters/bond_distributions.py
@@ -106,6 +106,8 @@ def calc_bond_length_distribution(
     :param plotfile: filename for saving bond length distribution pdf plots
     :type plotfile: str
     
+    :returns:
+       - bond_hist_data ( dict )
     """   
     
     # Convert file_list to list if a single string:

--- a/analyze_foldamers/parameters/bond_distributions.py
+++ b/analyze_foldamers/parameters/bond_distributions.py
@@ -8,6 +8,7 @@ import matplotlib
 import matplotlib.pyplot as plt
 import matplotlib.gridspec as gridspec
 from matplotlib.backends.backend_pdf import PdfPages
+from analyze_foldamers.parameters.bond_distributions import *
 
 def assign_bond_types(cgmodel, bond_list):
     """Internal function for assigning bond types"""

--- a/analyze_foldamers/parameters/bond_distributions.py
+++ b/analyze_foldamers/parameters/bond_distributions.py
@@ -52,8 +52,8 @@ def assign_bond_types(cgmodel, bond_list):
             bond_dict[reverse_string_name] = i_bond_type
             # For inverse dict we will use only the forward name based on first encounter
             inv_bond_dict[str(i_bond_type)] = string_name
-            print(f"adding new bond type {i_bond_type}: {string_name} to dictionary")
-            print(f"adding reverse version {i_bond_type}: {reverse_string_name} to dictionary")
+            # print(f"adding new bond type {i_bond_type}: {string_name} to dictionary")
+            # print(f"adding reverse version {i_bond_type}: {reverse_string_name} to dictionary")
             
         bond_types.append(bond_dict[string_name])
 

--- a/analyze_foldamers/parameters/bond_distributions.py
+++ b/analyze_foldamers/parameters/bond_distributions.py
@@ -8,7 +8,6 @@ import matplotlib
 import matplotlib.pyplot as plt
 import matplotlib.gridspec as gridspec
 from matplotlib.backends.backend_pdf import PdfPages
-from analyze_foldamers.parameters.bond_distributions import *
 
 def assign_bond_types(cgmodel, bond_list):
     """Internal function for assigning bond types"""

--- a/analyze_foldamers/tests/test_angle_distributions.py
+++ b/analyze_foldamers/tests/test_angle_distributions.py
@@ -261,3 +261,135 @@ def test_ramachandran_calc_dcd(tmpdir):
     # Fit ramachandran data to 2d Gaussian:
     param_opt, param_cov = fit_ramachandran_data(rama_hist, xedges, yedges)    
     
+    
+def test_2d_dist_bond_bond_dcd(tmpdir):
+    """Test general 2d histogram - bond-bond correlation"""
+    output_directory = tmpdir.mkdir("output")
+    
+    # Load in a trajectory pdb file:
+    traj_file = os.path.join(data_path, "replica_1.dcd")
+    
+    # Load in a CGModel:
+    cgmodel_path = os.path.join(data_path, "stored_cgmodel.pkl")
+    cgmodel = pickle.load(open(cgmodel_path, "rb"))
+
+    hist_out, xedges, yedges = calc_2d_distribution(
+        cgmodel,
+        traj_file,
+        plotfile=f"{output_directory}/bond_bond_2d.pdf",
+        xvar_name='bb_bb',
+        yvar_name='bb_sc',
+    )
+     
+    assert os.path.isfile(f"{output_directory}/bond_bond_2d.pdf")
+    
+    
+def test_2d_dist_bond_angle_dcd(tmpdir):
+    """Test general 2d histogram - bond-angle correlation"""
+    output_directory = tmpdir.mkdir("output")
+    
+    # Load in a trajectory pdb file:
+    traj_file = os.path.join(data_path, "replica_1.dcd")
+    
+    # Load in a CGModel:
+    cgmodel_path = os.path.join(data_path, "stored_cgmodel.pkl")
+    cgmodel = pickle.load(open(cgmodel_path, "rb"))
+
+    hist_out, xedges, yedges = calc_2d_distribution(
+        cgmodel,
+        traj_file,
+        plotfile=f"{output_directory}/bond_angle_2d.pdf",
+        xvar_name='bb_bb',
+        yvar_name='bb_bb_sc',
+    )
+     
+    assert os.path.isfile(f"{output_directory}/bond_angle_2d.pdf")     
+    
+    
+def test_2d_dist_bond_torsion_dcd(tmpdir):
+    """Test general 2d histogram - bond-torsion correlation"""
+    output_directory = tmpdir.mkdir("output")
+    
+    # Load in a trajectory pdb file:
+    traj_file = os.path.join(data_path, "replica_1.dcd")
+    
+    # Load in a CGModel:
+    cgmodel_path = os.path.join(data_path, "stored_cgmodel.pkl")
+    cgmodel = pickle.load(open(cgmodel_path, "rb"))
+
+    hist_out, xedges, yedges = calc_2d_distribution(
+        cgmodel,
+        traj_file,
+        plotfile=f"{output_directory}/bond_torsion_2d.pdf",
+        xvar_name='bb_bb',
+        yvar_name='bb_bb_bb_sc',
+    )
+     
+    assert os.path.isfile(f"{output_directory}/bond_torsion_2d.pdf")
+    
+
+def test_2d_dist_angle_angle_dcd(tmpdir):
+    """Test general 2d histogram - angle-angle correlation"""
+    output_directory = tmpdir.mkdir("output")
+    
+    # Load in a trajectory pdb file:
+    traj_file = os.path.join(data_path, "replica_1.dcd")
+    
+    # Load in a CGModel:
+    cgmodel_path = os.path.join(data_path, "stored_cgmodel.pkl")
+    cgmodel = pickle.load(open(cgmodel_path, "rb"))
+
+    hist_out, xedges, yedges = calc_2d_distribution(
+        cgmodel,
+        traj_file,
+        plotfile=f"{output_directory}/angle_angle_2d.pdf",
+        xvar_name='bb_bb_bb',
+        yvar_name='sc_bb_bb',
+    )
+     
+    assert os.path.isfile(f"{output_directory}/angle_angle_2d.pdf")
+    
+    
+def test_2d_dist_angle_torsion_dcd(tmpdir):
+    """Test general 2d histogram - angle-torsion correlation"""
+    output_directory = tmpdir.mkdir("output")
+    
+    # Load in a trajectory pdb file:
+    traj_file = os.path.join(data_path, "replica_1.dcd")
+    
+    # Load in a CGModel:
+    cgmodel_path = os.path.join(data_path, "stored_cgmodel.pkl")
+    cgmodel = pickle.load(open(cgmodel_path, "rb"))
+
+    hist_out, xedges, yedges = calc_2d_distribution(
+        cgmodel,
+        traj_file,
+        plotfile=f"{output_directory}/angle_torsion_2d.pdf",
+        xvar_name='bb_bb_sc',
+        yvar_name='bb_bb_bb_sc',
+    )
+     
+    assert os.path.isfile(f"{output_directory}/angle_torsion_2d.pdf")   
+
+
+def test_2d_dist_torsion_torsion_dcd(tmpdir):
+    """Test general 2d histogram - torsion-torsion correlation"""
+    output_directory = tmpdir.mkdir("output")
+    
+    # Load in a trajectory pdb file:
+    traj_file = os.path.join(data_path, "replica_1.dcd")
+    
+    # Load in a CGModel:
+    cgmodel_path = os.path.join(data_path, "stored_cgmodel.pkl")
+    cgmodel = pickle.load(open(cgmodel_path, "rb"))
+
+    hist_out, xedges, yedges = calc_2d_distribution(
+        cgmodel,
+        traj_file,
+        plotfile=f"{output_directory}/torsion_torsion_2d.pdf",
+        xvar_name='bb_bb_bb_sc',
+        yvar_name='sc_bb_bb_sc',
+    )
+     
+    assert os.path.isfile(f"{output_directory}/torsion_torsion_2d.pdf")       
+    

--- a/examples/angle_distributions/new_angle_distributions/calc_general_2d_distributions.py
+++ b/examples/angle_distributions/new_angle_distributions/calc_general_2d_distributions.py
@@ -1,0 +1,32 @@
+import os
+import numpy as np
+from simtk import unit
+from cg_openmm.cg_model.cgmodel import CGModel
+import pickle
+from analyze_foldamers.parameters.bond_distributions import *
+from analyze_foldamers.parameters.angle_distributions import *
+
+# This script calculates and plots 2d histograms for any combination of bonded parameters,
+# given a CGModel object and list of trajectory files (pdb or dcd).
+
+# Load in a trajectory pdb file:
+
+file_list = []
+file_list.append('output/state_1.pdb')
+
+# Load in a CGModel:
+cgmodel = pickle.load(open("stored_cgmodel.pkl","rb"))
+
+hist_data, xedges, yedges = calc_2d_distribution(
+    cgmodel,
+    file_list,
+    nbin_xvar=180,
+    nbin_yvar=180,
+    frame_start=10000,
+    frame_stride=1,
+    frame_end=-1,
+    plotfile="2d_hist.pdf",
+    xvar_name = "bb_bb_bb_sc",
+    yvar_name = "sc_bb_bb_sc",
+    colormap="Spectral",
+)


### PR DESCRIPTION
## Description
Generalized the ramachandran code to be able to plot 2d histograms of any combination of bonds, angles, and dihedrals. Since there are not in general the same number of observables for each bonded parameter, all combinations of the two bonded parameter observables are used in the histogram. 

For example, if we have x bonds of type bb-bb, and y bonds of type bb-sc, and a trajectory with n frames, the size of the 2 vectors to be histogrammed is `x*y*n`.

Also fixed an issue with the number of rows and columns for the subplots for cases in which the number of files is not a square number.