### PR TITLE
fix medoid index bug, add core point medoid option

### DIFF
--- a/analyze_foldamers/ensembles/cluster.py
+++ b/analyze_foldamers/ensembles/cluster.py
@@ -73,7 +73,6 @@ def get_cluster_medoid_positions_KMedoids(
     file_list, cgmodel, n_clusters=2,
     frame_start=0, frame_stride=1, frame_end=-1,
     output_format="pdb", output_dir="cluster_output",
-    core_points_medoid_option
     output_cluster_traj=False, plot_silhouette=True, plot_rmsd_hist=True,
     filter=False, filter_ratio=0.25, return_original_indices=False):
     """

--- a/analyze_foldamers/tests/test_rmsd_clustering.py
+++ b/analyze_foldamers/tests/test_rmsd_clustering.py
@@ -95,6 +95,7 @@ def test_clustering_kmedoids_pdb_no_cgmodel(tmpdir):
     assert os.path.isfile(f"{output_directory}/silhouette_kmedoids_ncluster_{n_clusters}.pdf") 
     assert os.path.isfile(f"{output_directory}/distances_rmsd_hist.pdf")
     
+    
 def test_clustering_kmedoids_dcd(tmpdir):
     """Test KMedoids clustering"""
     
@@ -176,10 +177,55 @@ def test_clustering_dbscan_pdb(tmpdir):
             plot_rmsd_hist=True,
             filter=True,
             filter_ratio=0.20,
+            core_points_only=False,
         )
     
     assert os.path.isfile(f"{output_directory}/medoid_0.pdb")
     assert os.path.isfile(f"{output_directory}/distances_rmsd_hist.pdf")
+    
+def test_clustering_dbscan_pdb_core_medoids(tmpdir):
+    """Test DBSCAN clustering"""
+    
+    output_directory = tmpdir.mkdir("output")
+    
+    # Load in cgmodel
+    cgmodel_path = os.path.join(data_path, "stored_cgmodel.pkl")
+    cgmodel = pickle.load(open(cgmodel_path, "rb"))
+    
+    # Create list of trajectory files for clustering analysis
+    number_replicas = 12
+    pdb_file_list = []
+    for i in range(number_replicas):
+        pdb_file_list.append(f"{data_path}/replica_%s.pdb" %(i+1))
+
+    # Set clustering parameters
+    min_samples=3
+    eps=0.5
+    frame_start=10
+    frame_stride=1
+    frame_end=-1
+
+    # Run DBSCAN density-based clustering
+    medoid_positions, cluster_sizes, cluster_rmsd, n_noise, silhouette_avg = \
+        get_cluster_medoid_positions_DBSCAN(
+            pdb_file_list,
+            cgmodel,
+            min_samples=min_samples,
+            eps=eps,
+            frame_start=frame_start,
+            frame_stride=frame_stride,
+            frame_end=-1,
+            output_dir=output_directory,
+            plot_silhouette=True,
+            plot_rmsd_hist=True,
+            filter=True,
+            filter_ratio=0.20,
+            core_points_only=True,
+        )
+    
+    assert os.path.isfile(f"{output_directory}/medoid_0.pdb")
+    assert os.path.isfile(f"{output_directory}/distances_rmsd_hist.pdf")
+    
 
 def test_clustering_dbscan_pdb_no_cgmodel(tmpdir):
     """Test DBSCAN clustering without cgmodel object"""
@@ -214,6 +260,7 @@ def test_clustering_dbscan_pdb_no_cgmodel(tmpdir):
             plot_rmsd_hist=True,
             filter=True,
             filter_ratio=0.20,
+            core_points_only=False,
         )
     
     assert os.path.isfile(f"{output_directory}/medoid_0.pdb")
@@ -258,6 +305,7 @@ def test_clustering_dbscan_dcd(tmpdir):
             plot_rmsd_hist=True,
             filter=True,
             filter_ratio=0.20,
+            core_points_only=False,
         )
     
     assert os.path.isfile(f"{output_directory}/medoid_0.dcd")    

--- a/analyze_foldamers/tests/test_torsion_clustering.py
+++ b/analyze_foldamers/tests/test_torsion_clustering.py
@@ -138,6 +138,7 @@ def test_cluster_torsions_dbscan_pdb(tmpdir):
             plot_distance_hist=True,
             filter=True,
             filter_ratio=0.20,
+            core_points_only=False,
         )
     
     assert os.path.isfile(f"{output_directory}/medoid_0.pdb")
@@ -182,6 +183,52 @@ def test_cluster_torsions_dbscan_dcd(tmpdir):
             plot_distance_hist=True,
             filter=True,
             filter_ratio=0.20,
+            core_points_only=False,
+        )
+    
+    assert os.path.isfile(f"{output_directory}/medoid_0.dcd")    
+    assert os.path.isfile(f"{output_directory}/torsion_distances_hist.pdf")
+    
+    
+def test_cluster_torsions_dbscan_dcd_core_medoids(tmpdir):
+    """Test DBSCAN clustering"""
+    
+    output_directory = tmpdir.mkdir("output")
+    
+    # Load in cgmodel
+    cgmodel_path = os.path.join(data_path, "stored_cgmodel.pkl")
+    cgmodel = pickle.load(open(cgmodel_path, "rb"))
+    
+    # Create list of trajectory files for clustering analysis
+    number_replicas = 12
+    dcd_file_list = []
+    for i in range(number_replicas):
+        dcd_file_list.append(f"{data_path}/replica_%s.dcd" %(i+1))
+
+    # Set clustering parameters
+    min_samples=3
+    eps=50
+    frame_start=10
+    frame_stride=2
+    frame_end=-1
+
+    # Run OPTICS density-based clustering
+    medoid_positions, medoid_torsions, cluster_sizes, cluster_rmsd, n_noise, silhouette_avg = \
+        cluster_torsions_DBSCAN(
+            dcd_file_list,
+            cgmodel,
+            min_samples=min_samples,
+            eps=eps,
+            frame_start=frame_start,
+            frame_stride=frame_stride,
+            frame_end=-1,
+            output_format="dcd",
+            output_dir=output_directory,
+            plot_silhouette=True,
+            plot_distance_hist=True,
+            filter=True,
+            filter_ratio=0.20,
+            core_points_only=True,
         )
     
     assert os.path.isfile(f"{output_directory}/medoid_0.dcd")    


### PR DESCRIPTION
## Description
- Added option for using just core points within each cluster to determine its medoid (DBSCAN only - we can revisit OPTICS later on)
- Fixed a bug where the intra-cluster medoid indices were wrongly applied to the full trajectory, resulting in the wrong structure being written to the medoid file  

## Status
- [x] Ready to go