### PR TITLE
update test environment for python 3.8 support

### DIFF
--- a/devtools/conda-envs/test_env.yaml
+++ b/devtools/conda-envs/test_env.yaml
@@ -5,21 +5,21 @@ channels:
   - defaults
 dependencies:
   - matplotlib-base
-  - mdtraj=1.9.4
-  - mpi4py=3.0.3
-  - numpy=1.18.5
-  - openmm=7.4.2
-  - openmmtools=0.19.0
+  - mdtraj
+  - mpi4py
+  - numpy
+  - openmm
+  - openmmtools
   - pickleshare
   - pip
-  - pymbar=3.0.5
+  - pymbar
   - pytest
   - pytest-cov
   - python
   - pyyaml
-  - scikit-learn=0.23.1
+  - scikit-learn
   - scikit-learn-extra
-  - scipy=1.4.1
+  - scipy
   - yaml
 
   # Pip-only installs


### PR DESCRIPTION
## Description
This fixes an issue with creating the conda test environment for python 3.8. Specifically, somewhere in the past month or so the OpenMM 7.4.2 build for python 3.8 on conda-forge stopped working (listed here as broken: https://anaconda.org/conda-forge/openmm/files?version=7.4.2).

I got rid of all version specs in test_env.yml, which results in OpenMM 7.5.1 being used. All tests are passing now.