### PR TITLE
add mapping to common bonded types

### DIFF
--- a/analyze_foldamers/parameters/angle_distributions.py
+++ b/analyze_foldamers/parameters/angle_distributions.py
@@ -14,7 +14,7 @@ from scipy.optimize import curve_fit
 
 # These functions calculate and plot bond angle and torsion distributions from a CGModel object and pdb trajectory
 
-def assign_angle_types(cgmodel, angle_list):
+def assign_angle_types(cgmodel, angle_list, particle_mapping=None):
     """Internal function for assigning angle types"""
     
     ang_types = [] # List of angle types for each angle in angle_list
@@ -37,11 +37,18 @@ def assign_angle_types(cgmodel, angle_list):
         ang_array[i,1] = angle_list[i][1]
         ang_array[i,2] = angle_list[i][2]
         
-        particle_types = [
-            CGModel.get_particle_type_name(cgmodel,angle_list[i][0]),
-            CGModel.get_particle_type_name(cgmodel,angle_list[i][1]),
-            CGModel.get_particle_type_name(cgmodel,angle_list[i][2])
-        ]
+        if particle_mapping is None:
+            particle_types = [
+                CGModel.get_particle_type_name(cgmodel,angle_list[i][0]),
+                CGModel.get_particle_type_name(cgmodel,angle_list[i][1]),
+                CGModel.get_particle_type_name(cgmodel,angle_list[i][2])
+            ]
+        else:
+            particle_types = [
+                particle_mapping[CGModel.get_particle_type_name(cgmodel,angle_list[i][0])],
+                particle_mapping[CGModel.get_particle_type_name(cgmodel,angle_list[i][1])],
+                particle_mapping[CGModel.get_particle_type_name(cgmodel,angle_list[i][2])]
+            ]
         
         string_name = ""
         reverse_string_name = ""
@@ -79,7 +86,7 @@ def assign_angle_types(cgmodel, angle_list):
     return ang_types, ang_array, ang_sub_arrays, n_i, i_angle_type, ang_dict, inv_ang_dict
     
 
-def assign_torsion_types(cgmodel, torsion_list):
+def assign_torsion_types(cgmodel, torsion_list, particle_mapping=None):
     """Internal function for assigning torsion types"""
     
     torsion_types = [] # List of torsion types for each torsion in torsion_list
@@ -100,12 +107,20 @@ def assign_torsion_types(cgmodel, torsion_list):
         torsion_array[i,2] = torsion_list[i][2]
         torsion_array[i,3] = torsion_list[i][3]
         
-        particle_types = [
-            CGModel.get_particle_type_name(cgmodel,torsion_list[i][0]),
-            CGModel.get_particle_type_name(cgmodel,torsion_list[i][1]),
-            CGModel.get_particle_type_name(cgmodel,torsion_list[i][2]),
-            CGModel.get_particle_type_name(cgmodel,torsion_list[i][3])
-        ]
+        if particle_mapping is None:
+            particle_types = [
+                CGModel.get_particle_type_name(cgmodel,torsion_list[i][0]),
+                CGModel.get_particle_type_name(cgmodel,torsion_list[i][1]),
+                CGModel.get_particle_type_name(cgmodel,torsion_list[i][2]),
+                CGModel.get_particle_type_name(cgmodel,torsion_list[i][3])
+            ]
+        else:
+            particle_types = [
+                particle_mapping[CGModel.get_particle_type_name(cgmodel,torsion_list[i][0])],
+                particle_mapping[CGModel.get_particle_type_name(cgmodel,torsion_list[i][1])],
+                particle_mapping[CGModel.get_particle_type_name(cgmodel,torsion_list[i][2])],
+                particle_mapping[CGModel.get_particle_type_name(cgmodel,torsion_list[i][3])]
+            ]
         
         string_name = ""
         reverse_string_name = ""
@@ -147,7 +162,8 @@ def assign_torsion_types(cgmodel, torsion_list):
 
 def calc_bond_angle_distribution(
     cgmodel, file_list, nbins=90, frame_start=0, frame_stride=1, frame_end=-1, 
-    plot_per_page=2, temperature_list=None, plotfile="angle_hist.pdf"
+    plot_per_page=2, temperature_list=None, plotfile="angle_hist.pdf",
+    particle_mapping=None,
     ):
     """
     Calculate and plot all bond angle distributions from a CGModel object and pdb trajectory
@@ -179,6 +195,9 @@ def calc_bond_angle_distribution(
     :param plotfile: Base filename for saving bond angle distribution pdf plots
     :type plotfile: str
     
+    :param particle_mapping: dictionary mapping specific particle types to more general bonded types (for example, 'sc1' --> 'sc')
+    :type particle_mapping: dict(str:str)    
+    
     :returns:
        - angle_hist_data ( dict )    
     
@@ -194,7 +213,7 @@ def calc_bond_angle_distribution(
     
     # Assign angle types:
     ang_types, ang_array, ang_sub_arrays, n_i, i_angle_type, ang_dict, inv_ang_dict = \
-        assign_angle_types(cgmodel, angle_list)
+        assign_angle_types(cgmodel, angle_list, particle_mapping=particle_mapping)
          
     # Create dictionary for saving angle histogram data:
     angle_hist_data = {}
@@ -264,7 +283,8 @@ def calc_bond_angle_distribution(
     
 def calc_torsion_distribution(
     cgmodel, file_list, nbins=180, frame_start=0, frame_stride=1, frame_end=-1,
-    plot_per_page=2, temperature_list=None, plotfile="torsion_hist.pdf"
+    plot_per_page=2, temperature_list=None, plotfile="torsion_hist.pdf",
+    particle_mapping=None,
     ):
     """
     Calculate and plot all torsion distributions from a CGModel object and pdb or dcd trajectory
@@ -296,6 +316,9 @@ def calc_torsion_distribution(
     :param plotfile: Base filename for saving torsion distribution pdf plots
     :type plotfile: str
     
+    :param particle_mapping: dictionary mapping specific particle types to more general bonded types (for example, 'sc1' --> 'sc')
+    :type particle_mapping: dict(str:str)
+    
     :returns:
        - torsion_hist_data ( dict )
     
@@ -311,7 +334,7 @@ def calc_torsion_distribution(
     
     # Assign torsion types
     torsion_types, torsion_array, torsion_sub_arrays, n_i, i_torsion_type, torsion_dict, inv_torsion_dict = \
-        assign_torsion_types(cgmodel, torsion_list)
+        assign_torsion_types(cgmodel, torsion_list, particle_mapping=particle_mapping)
     
     # Create dictionary for saving torsion histogram data:
     torsion_hist_data = {}
@@ -391,6 +414,7 @@ def calc_2d_distribution(
     yvar_name = "bb_bb_bb_bb",
     colormap="nipy_spectral",
     temperature_list=None,
+    particle_mapping=None,
     ):      
 
     """
@@ -421,10 +445,10 @@ def calc_2d_distribution(
     :param plotfile: Filename for saving torsion distribution pdf plots
     :type plotfile: str
     
-    :param xvar_name: particle sequence of the x bonded parameter (default="bb_bb_bb")
+    :param xvar_name: particle sequence of the x bonded parameter, after any particle type mapping (default="bb_bb_bb")
     :type xvar_name: str
     
-    :param yvar_name: particle sequence of the y bonded parameter (default="bb_bb_bb_bb")
+    :param yvar_name: particle sequence of the y bonded parameter, after any particle type mapping (default="bb_bb_bb_bb")
     :type yvar_name: str    
     
     :param colormap: matplotlib pyplot colormap to use (default='nipy_spectral')
@@ -432,6 +456,9 @@ def calc_2d_distribution(
     
     :param temperature_list: list of temperatures corresponding to file_list. If None, no subplot labels will be used.
     :type temperature_list: list(Quantity()) 
+    
+    :param particle_mapping: dictionary mapping specific particle types to more general bonded types (for example, 'sc1' --> 'sc')
+    :type particle_mapping: dict(str:str)    
     
     :returns:
        - hist_data ( dict )
@@ -517,7 +544,7 @@ def calc_2d_distribution(
             
             # Assign bond types:
             bond_types, bond_array, bond_sub_arrays, n_i, i_bond_type, bond_dict, inv_bond_dict = \
-                assign_bond_types(cgmodel, bond_list)
+                assign_bond_types(cgmodel, bond_list, particle_mapping=particle_mapping)
             
             for i in range(i_bond_type):
                 if inv_bond_dict[str(i+1)] == xvar_name or inv_bond_dict[str(i+1)] == xvar_name_reverse:
@@ -548,7 +575,7 @@ def calc_2d_distribution(
         
             # Assign angle types:
             ang_types, ang_array, ang_sub_arrays, n_i, i_angle_type, ang_dict, inv_ang_dict = \
-                assign_angle_types(cgmodel, angle_list)
+                assign_angle_types(cgmodel, angle_list, particle_mapping=particle_mapping)
                 
             # Set bin edges:
             xvar_bin_edges = np.linspace(0,180,nbin_xvar+1)
@@ -575,7 +602,7 @@ def calc_2d_distribution(
 
             # Assign torsion types
             torsion_types, torsion_array, torsion_sub_arrays, n_j, i_torsion_type, torsion_dict, inv_torsion_dict = \
-                assign_torsion_types(cgmodel, torsion_list)
+                assign_torsion_types(cgmodel, torsion_list, particle_mapping=particle_mapping)
             
             # Set bin edges:
             xvar_bin_edges = np.linspace(-180,180,nbin_xvar+1)
@@ -608,7 +635,7 @@ def calc_2d_distribution(
             
             # Assign bond types:
             bond_types, bond_array, bond_sub_arrays, n_i, i_bond_type, bond_dict, inv_bond_dict = \
-                assign_bond_types(cgmodel, bond_list)
+                assign_bond_types(cgmodel, bond_list, particle_mapping=particle_mapping)
             
             for i in range(i_bond_type):
                 if inv_bond_dict[str(i+1)] == yvar_name or inv_bond_dict[str(i+1)] == yvar_name_reverse:
@@ -639,7 +666,7 @@ def calc_2d_distribution(
         
             # Assign angle types:
             ang_types, ang_array, ang_sub_arrays, n_i, i_angle_type, ang_dict, inv_ang_dict = \
-                assign_angle_types(cgmodel, angle_list)
+                assign_angle_types(cgmodel, angle_list, particle_mapping=particle_mapping)
                 
             # Set bin edges:
             yvar_bin_edges = np.linspace(0,180,nbin_yvar+1)
@@ -666,7 +693,7 @@ def calc_2d_distribution(
 
             # Assign torsion types
             torsion_types, torsion_array, torsion_sub_arrays, n_j, i_torsion_type, torsion_dict, inv_torsion_dict = \
-                assign_torsion_types(cgmodel, torsion_list)
+                assign_torsion_types(cgmodel, torsion_list, particle_mapping=particle_mapping)
             
             # Set bin edges:
             yvar_bin_edges = np.linspace(-180,180,nbin_yvar+1)
@@ -734,6 +761,7 @@ def calc_ramachandran(
     backbone_torsion_type = "bb_bb_bb_bb",
     colormap="nipy_spectral",
     temperature_list=None,
+    particle_mapping=None,
 ):
     """
     Calculate and plot ramachandran plot for backbone bond bending-angle and torsion
@@ -775,6 +803,9 @@ def calc_ramachandran(
     :param temperature_list: list of temperatures corresponding to file_list. If None, no subplot labels will be used.
     :type temperature_list: list(Quantity())    
     
+    :param particle_mapping: dictionary mapping specific particle types to more general bonded types (for example, 'sc1' --> 'sc')
+    :type particle_mapping: dict(str:str)    
+    
     :returns:
        - hist_data ( dict )
        - xedges ( dict )
@@ -812,7 +843,7 @@ def calc_ramachandran(
         
         # Assign angle types:
         ang_types, ang_array, ang_sub_arrays, n_i, i_angle_type, ang_dict, inv_ang_dict = \
-            assign_angle_types(cgmodel, angle_list)
+            assign_angle_types(cgmodel, angle_list, particle_mapping=particle_mapping)
         
         # Set bin edges:
         angle_bin_edges = np.linspace(0,180,nbin_theta+1)
@@ -840,7 +871,7 @@ def calc_ramachandran(
 
         # Assign torsion types
         torsion_types, torsion_array, torsion_sub_arrays, n_j, i_torsion_type, torsion_dict, inv_torsion_dict = \
-            assign_torsion_types(cgmodel, torsion_list)
+            assign_torsion_types(cgmodel, torsion_list, particle_mapping=particle_mapping)
         
         # Set bin edges:
         torsion_bin_edges = np.linspace(-180,180,nbin_alpha+1)

--- a/analyze_foldamers/parameters/angle_distributions.py
+++ b/analyze_foldamers/parameters/angle_distributions.py
@@ -195,7 +195,7 @@ def calc_bond_angle_distribution(
     :param plotfile: Base filename for saving bond angle distribution pdf plots
     :type plotfile: str
     
-    :param particle_mapping: dictionary mapping specific particle types to more general bonded types (for example, 'sc1' --> 'sc')
+    :param particle_mapping: dictionary mapping specific particle types to more general bonded types (for example, 'sc1' --> 'sc') (default=None)
     :type particle_mapping: dict(str:str)    
     
     :returns:
@@ -316,7 +316,7 @@ def calc_torsion_distribution(
     :param plotfile: Base filename for saving torsion distribution pdf plots
     :type plotfile: str
     
-    :param particle_mapping: dictionary mapping specific particle types to more general bonded types (for example, 'sc1' --> 'sc')
+    :param particle_mapping: dictionary mapping specific particle types to more general bonded types (for example, 'sc1' --> 'sc') (default=None)
     :type particle_mapping: dict(str:str)
     
     :returns:
@@ -457,7 +457,7 @@ def calc_2d_distribution(
     :param temperature_list: list of temperatures corresponding to file_list. If None, no subplot labels will be used.
     :type temperature_list: list(Quantity()) 
     
-    :param particle_mapping: dictionary mapping specific particle types to more general bonded types (for example, 'sc1' --> 'sc')
+    :param particle_mapping: dictionary mapping specific particle types to more general bonded types (for example, 'sc1' --> 'sc') (default=None)
     :type particle_mapping: dict(str:str)    
     
     :returns:
@@ -803,7 +803,7 @@ def calc_ramachandran(
     :param temperature_list: list of temperatures corresponding to file_list. If None, no subplot labels will be used.
     :type temperature_list: list(Quantity())    
     
-    :param particle_mapping: dictionary mapping specific particle types to more general bonded types (for example, 'sc1' --> 'sc')
+    :param particle_mapping: dictionary mapping specific particle types to more general bonded types (for example, 'sc1' --> 'sc') (default=None)
     :type particle_mapping: dict(str:str)    
     
     :returns:

--- a/analyze_foldamers/parameters/angle_distributions.py
+++ b/analyze_foldamers/parameters/angle_distributions.py
@@ -757,8 +757,8 @@ def calc_ramachandran(
     frame_stride=1,
     frame_end=-1,
     plotfile="ramachandran.pdf",
-    backbone_angle_type = "bb_bb_bb",
-    backbone_torsion_type = "bb_bb_bb_bb",
+    backbone_angle_type="bb_bb_bb",
+    backbone_torsion_type="bb_bb_bb_bb",
     colormap="nipy_spectral",
     temperature_list=None,
     particle_mapping=None,
@@ -791,10 +791,10 @@ def calc_ramachandran(
     :param plotfile: Filename for saving torsion distribution pdf plots
     :type plotfile: str
     
-    :param backbone_angle_type: particle sequence of the backbone angles (default="bb_bb_bb") - for now only single sequence permitted
+    :param backbone_angle_type: particle sequence of the backbone angles, after any particle type mapping (default="bb_bb_bb")
     :type backbone_angle_type: str
     
-    :param backbone_torsion_type: particle sequence of the backbone angles (default="bb_bb_bb_bb") - for now only single sequence permitted
+    :param backbone_torsion_type: particle sequence of the backbone angles, after any particle type mapping (default="bb_bb_bb_bb")
     :type backbone_torsion_type: str    
     
     :param colormap: matplotlib pyplot colormap to use (default='nipy_spectral')

--- a/analyze_foldamers/parameters/bond_distributions.py
+++ b/analyze_foldamers/parameters/bond_distributions.py
@@ -116,7 +116,7 @@ def calc_bond_length_distribution(
     :param plotfile: filename for saving bond length distribution pdf plots
     :type plotfile: str
     
-    :param particle_mapping: dictionary mapping specific particle types to more general bonded types (for example, 'sc1' --> 'sc')
+    :param particle_mapping: dictionary mapping specific particle types to more general bonded types (for example, 'sc1' --> 'sc') (default=None)
     :type particle_mapping: dict(str:str)
     
     :returns:

--- a/analyze_foldamers/parameters/bond_distributions.py
+++ b/analyze_foldamers/parameters/bond_distributions.py
@@ -11,14 +11,14 @@ from matplotlib.backends.backend_pdf import PdfPages
 from openmm import unit
 
 
-def assign_bond_types(cgmodel, bond_list):
+def assign_bond_types(cgmodel, bond_list, particle_mapping=None):
     """Internal function for assigning bond types"""
     
     bond_types = []
     
     bond_array = np.zeros((len(bond_list),2))
     
-    # Relevant bond types are added to a dictionary as they are discovered 
+    # Relevant bond types are added to a dictionary as they are discovered
     bond_dict = {}
     
     # Create an inverse dictionary for getting bond string name from integer type
@@ -33,10 +33,17 @@ def assign_bond_types(cgmodel, bond_list):
         bond_array[i,0] = bond_list[i][0]
         bond_array[i,1] = bond_list[i][1]
         
-        particle_types = [
-            CGModel.get_particle_type_name(cgmodel,bond_list[i][0]),
-            CGModel.get_particle_type_name(cgmodel,bond_list[i][1])
-        ]
+        if particle_mapping is None:
+            particle_types = [
+                CGModel.get_particle_type_name(cgmodel,bond_list[i][0]),
+                CGModel.get_particle_type_name(cgmodel,bond_list[i][1])
+            ]
+        else:
+            # Use particle_mapping dictionary to create more general bonded types:
+            particle_types = [
+                particle_mapping[CGModel.get_particle_type_name(cgmodel,bond_list[i][0])],
+                particle_mapping[CGModel.get_particle_type_name(cgmodel,bond_list[i][1])]
+            ]
         
         string_name = ""
         reverse_string_name = ""
@@ -76,7 +83,8 @@ def assign_bond_types(cgmodel, bond_list):
     
 def calc_bond_length_distribution(
     cgmodel, file_list, nbins=90, frame_start=0, frame_stride=1, frame_end=-1,
-    plot_per_page=2, temperature_list=None, plotfile="bond_hist.pdf"
+    plot_per_page=2, temperature_list=None, plotfile="bond_hist.pdf",
+    particle_mapping=None,
     ):
     """
     Calculate and plot all bond length distributions from a CGModel object and trajectory
@@ -108,6 +116,9 @@ def calc_bond_length_distribution(
     :param plotfile: filename for saving bond length distribution pdf plots
     :type plotfile: str
     
+    :param particle_mapping: dictionary mapping specific particle types to more general bonded types (for example, 'sc1' --> 'sc')
+    :type particle_mapping: dict(str:str)
+    
     :returns:
        - bond_hist_data ( dict )
     """   
@@ -125,7 +136,7 @@ def calc_bond_length_distribution(
     
     # Assign bond types:
     bond_types, bond_array, bond_sub_arrays, n_i, i_bond_type, bond_dict, inv_bond_dict = \
-        assign_bond_types(cgmodel, bond_list)
+        assign_bond_types(cgmodel, bond_list, particle_mapping=particle_mapping)
     
     file_index = 0
     for file in file_list:

--- a/analyze_foldamers/tests/test_angle_distributions.py
+++ b/analyze_foldamers/tests/test_angle_distributions.py
@@ -105,6 +105,33 @@ def test_bond_dist_calc_dcd(tmpdir):
     
     assert os.path.isfile(f"{output_directory}/bond_hist_dcd.pdf") 
     
+
+def test_bond_dist_calc_dcd_mapping(tmpdir):
+    """Test bond distribution calculator"""
+    
+    output_directory = tmpdir.mkdir("output")
+    
+    # Load in a trajectory dcd file:
+    traj_file = os.path.join(data_path, "replica_1.dcd")
+
+    # Load in a CGModel:
+    cgmodel_path = os.path.join(data_path, "stored_cgmodel.pkl")
+    cgmodel = pickle.load(open(cgmodel_path, "rb"))
+    
+    # Add a trivial particle type mapping:
+    particle_mapping = {}
+    particle_mapping['bb'] = 'b'
+    particle_mapping['sc'] = 's'
+
+    bond_hist_data = calc_bond_length_distribution(
+        cgmodel,
+        traj_file,
+        plotfile=f"{output_directory}/bond_hist_dcd.pdf",
+        particle_mapping=particle_mapping,
+    )
+    
+    assert os.path.isfile(f"{output_directory}/bond_hist_dcd.pdf")     
+    
     
 def test_bond_dist_calc_dcd_multi(tmpdir):
     """Test bond distribution calculator"""
@@ -150,6 +177,33 @@ def test_angle_dist_calc_dcd(tmpdir):
     assert os.path.isfile(f"{output_directory}/angle_hist_dcd.pdf") 
     
     
+def test_angle_dist_calc_dcd_mapping(tmpdir):
+    """Test angle distribution calculator"""
+    
+    output_directory = tmpdir.mkdir("output")
+    
+    # Load in a trajectory dcd file:
+    traj_file = os.path.join(data_path, "replica_1.dcd")
+
+    # Load in a CGModel:
+    cgmodel_path = os.path.join(data_path, "stored_cgmodel.pkl")
+    cgmodel = pickle.load(open(cgmodel_path, "rb"))
+
+    # Add a trivial particle type mapping:
+    particle_mapping = {}
+    particle_mapping['bb'] = 'b'
+    particle_mapping['sc'] = 's'
+
+    angle_hist_data = calc_bond_angle_distribution(
+        cgmodel,
+        traj_file,
+        plotfile=f"{output_directory}/angle_hist_dcd.pdf",
+        particle_mapping=particle_mapping,
+    )
+    
+    assert os.path.isfile(f"{output_directory}/angle_hist_dcd.pdf")     
+    
+    
 def test_angle_dist_calc_dcd_multi(tmpdir):
     """Test angle distribution calculator"""
     
@@ -192,6 +246,33 @@ def test_torsion_dist_calc_dcd(tmpdir):
     )
     
     assert os.path.isfile(f"{output_directory}/torsion_hist_dcd.pdf") 
+    
+    
+def test_torsion_dist_calc_dcd_mapping(tmpdir):
+    """Test torsion distribution calculator"""
+    
+    output_directory = tmpdir.mkdir("output")
+    
+    # Load in a trajectory dcd file:
+    traj_file = os.path.join(data_path, "replica_1.dcd")
+
+    # Load in a CGModel:
+    cgmodel_path = os.path.join(data_path, "stored_cgmodel.pkl")
+    cgmodel = pickle.load(open(cgmodel_path, "rb"))
+    
+    # Add a trivial particle type mapping:
+    particle_mapping = {}
+    particle_mapping['bb'] = 'b'
+    particle_mapping['sc'] = 's'    
+    
+    torsion_hist_data = calc_torsion_distribution(
+        cgmodel,
+        traj_file,
+        plotfile=f"{output_directory}/torsion_hist_dcd.pdf",
+        particle_mapping=particle_mapping,
+    )
+    
+    assert os.path.isfile(f"{output_directory}/torsion_hist_dcd.pdf")     
 
 
 def test_torsion_dist_calc_dcd_multi(tmpdir):
@@ -265,6 +346,39 @@ def test_ramachandran_calc_dcd(tmpdir):
     param_opt, param_cov = fit_ramachandran_data(rama_hist, xedges, yedges)    
     
     
+def test_ramachandran_calc_dcd_mapping(tmpdir):
+    """Test ramachandran calculation/plotting"""
+
+    output_directory = tmpdir.mkdir("output")
+    
+    # Load in a trajectory pdb file:
+    traj_file = os.path.join(data_path, "replica_1.dcd")
+    
+    # Load in a CGModel:
+    cgmodel_path = os.path.join(data_path, "stored_cgmodel.pkl")
+    cgmodel = pickle.load(open(cgmodel_path, "rb"))    
+    
+    # Add a trivial particle type mapping:
+    particle_mapping = {}
+    particle_mapping['bb'] = 'b'
+    particle_mapping['sc'] = 's'      
+    
+    rama_hist, xedges, yedges = calc_ramachandran(
+        cgmodel,
+        traj_file,
+        backbone_angle_type='b_b_b',
+        backbone_torsion_type='b_b_b_b',
+        plotfile=f"{output_directory}/ramachandran_dcd.pdf",
+        particle_mapping=particle_mapping,
+    )
+     
+    assert os.path.isfile(f"{output_directory}/ramachandran_dcd.pdf") 
+     
+    # Fit ramachandran data to 2d Gaussian:
+    param_opt, param_cov = fit_ramachandran_data(rama_hist, xedges, yedges)    
+        
+    
+    
 def test_2d_dist_bond_bond_dcd(tmpdir):
     """Test general 2d histogram - bond-bond correlation"""
     output_directory = tmpdir.mkdir("output")
@@ -307,6 +421,34 @@ def test_2d_dist_bond_angle_dcd(tmpdir):
     )
      
     assert os.path.isfile(f"{output_directory}/bond_angle_2d.pdf")     
+    
+
+def test_2d_dist_bond_angle_dcd_mapping(tmpdir):
+    """Test general 2d histogram - bond-angle correlation"""
+    output_directory = tmpdir.mkdir("output")
+    
+    # Load in a trajectory pdb file:
+    traj_file = os.path.join(data_path, "replica_1.dcd")
+    
+    # Load in a CGModel:
+    cgmodel_path = os.path.join(data_path, "stored_cgmodel.pkl")
+    cgmodel = pickle.load(open(cgmodel_path, "rb"))
+    
+    # Add a trivial particle type mapping:
+    particle_mapping = {}
+    particle_mapping['bb'] = 'b'
+    particle_mapping['sc'] = 's'
+
+    hist_out, xedges, yedges = calc_2d_distribution(
+        cgmodel,
+        traj_file,
+        plotfile=f"{output_directory}/bond_angle_2d.pdf",
+        xvar_name='b_b',
+        yvar_name='b_b_s',
+        particle_mapping=particle_mapping,
+    )
+     
+    assert os.path.isfile(f"{output_directory}/bond_angle_2d.pdf")        
     
     
 def test_2d_dist_bond_torsion_dcd(tmpdir):
@@ -373,6 +515,56 @@ def test_2d_dist_angle_torsion_dcd(tmpdir):
     )
      
     assert os.path.isfile(f"{output_directory}/angle_torsion_2d.pdf")   
+    
+    
+def test_2d_dist_angle_torsion_dcd_mapping(tmpdir):
+    """Test general 2d histogram - angle-torsion correlation"""
+    output_directory = tmpdir.mkdir("output")
+    
+    # Load in a trajectory pdb file:
+    traj_file = os.path.join(data_path, "replica_1.dcd")
+    
+    # Load in a CGModel:
+    cgmodel_path = os.path.join(data_path, "stored_cgmodel.pkl")
+    cgmodel = pickle.load(open(cgmodel_path, "rb"))
+
+    # Add a trivial particle type mapping:
+    particle_mapping = {}
+    particle_mapping['bb'] = 'b'
+    particle_mapping['sc'] = 's'
+
+    hist_out, xedges, yedges = calc_2d_distribution(
+        cgmodel,
+        traj_file,
+        plotfile=f"{output_directory}/angle_torsion_2d.pdf",
+        xvar_name='b_b_s',
+        yvar_name='b_b_b_s',
+        particle_mapping=particle_mapping,
+    )
+     
+    assert os.path.isfile(f"{output_directory}/angle_torsion_2d.pdf")       
+    
+    
+def test_2d_dist_torsion_torsion_dcd(tmpdir):
+    """Test general 2d histogram - angle-torsion correlation"""
+    output_directory = tmpdir.mkdir("output")
+    
+    # Load in a trajectory pdb file:
+    traj_file = os.path.join(data_path, "replica_1.dcd")
+    
+    # Load in a CGModel:
+    cgmodel_path = os.path.join(data_path, "stored_cgmodel.pkl")
+    cgmodel = pickle.load(open(cgmodel_path, "rb"))
+
+    hist_out, xedges, yedges = calc_2d_distribution(
+        cgmodel,
+        traj_file,
+        plotfile=f"{output_directory}/angle_torsion_2d.pdf",
+        xvar_name='bb_bb_bb_bb',
+        yvar_name='bb_bb_bb_sc',
+    )
+     
+    assert os.path.isfile(f"{output_directory}/angle_torsion_2d.pdf")       
 
 
 def test_radius_gyration_pdb(tmpdir):

--- a/examples/angle_distributions/calc_angle_distributions.py
+++ b/examples/angle_distributions/calc_angle_distributions.py
@@ -16,6 +16,23 @@ traj_file = "simulation.pdb"
 # Load in a CGModel:
 cgmodel = pickle.load(open("stored_cgmodel.pkl","rb"))
 
-angle_hist_data = calc_bond_angle_distribution(cgmodel,traj_file)
-torsion_hist_data = calc_torsion_distribution(cgmodel,traj_file)
+# With a mapping dictionary, we can rename particle type names or 
+# combine multiple particle types into a common bonded type:
+
+particle_mapping = {
+    'bb': 'b',
+    'sc': 's',
+    }
+
+angle_hist_data = calc_bond_angle_distribution(
+    cgmodel,
+    traj_file,
+    particle_mapping=particle_mapping,
+    )
+    
+torsion_hist_data = calc_torsion_distribution(
+    cgmodel,
+    traj_file,
+    particle_mapping=particle_mapping,
+    )
 


### PR DESCRIPTION
## Description
For all bonded distribution functions, we can now pass a dictionary mapping specific particle types to more general bonded particle types when we want them to be treated the same.

One example this is useful is in Go models in which each bead is assigned its own particle type so that the strengths of native and non-native interactions can be modified, but with bonded potentials treated in the same way as a standard non-Go model. For example if we have specific particle types 'b1','b2','b3','s1','s2','s3', but want backbone 'b' and sidechain 's' to be treated identically for bonded distributions, we would pass in the following map when computing the distributions:

`particle_mapping = {
    'b1':'b',
    'b2':'b',
    'b3':'b',
    's1':'s',
    's2':'s',
    's3':'s'
    }`

## Todos
  - [x] Add example script

## Status
- [x] Ready to go